### PR TITLE
allow proxyforeignkey to point to nonproxy model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Usage is pretty simple:
 
 You may only override fields that exist, although in the future, it may be possible to create a relation with a different name (enabling you to keep the standard relation to the non-proxy model).
 
-You may also only override with a compatible field, and can only point to another proxy model (and only one proxy model may point to any other given proxy model).
+You may also only override with a compatible field (and only one proxy model may point to any other given proxy model).
 
 
 It is also possible to override non-related models, but I'm not that interested in that use case at the moment.

--- a/proxy_overrides/base.py
+++ b/proxy_overrides/base.py
@@ -14,11 +14,6 @@ def override_model_field(model, name, field):
         ))
 
     if field.remote_field:
-        # Ensure we are referencing another proxy class.
-        if not field.remote_field.model._meta.proxy:
-            raise TypeError('You must relate to another proxy class, not {!r}'.format(
-                field.remote_field.model.__name__
-            ))
 
         related_name = field.remote_field.related_name
         if not related_name:

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,12 +8,16 @@ class Foo(models.Model):
 
 
 class Bar(models.Model):
-    pass
+    a = models.IntegerField(default=1)
 
 
 class BarProxy(Bar):
     class Meta:
         proxy = True
+
+
+class BarChild(Bar):
+    b = models.IntegerField(default=2)
 
 
 class FooProxy(Foo):
@@ -23,16 +27,11 @@ class FooProxy(Foo):
         proxy = True
 
 
-class BarProxy2(Bar):
+class FooChildProxy(Foo):
+    bar = ProxyForeignKey(BarChild, on_delete='null')
+
     class Meta:
         proxy = True
-
-
-# class FooStringProxy(Foo):
-#     bar = ProxyForeignKey('tests.BarProxy2')
-#
-#     class Meta:
-#         proxy = True
 
 
 class Baz(models.Model):

--- a/tests/test_related.py
+++ b/tests/test_related.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from .models import Foo, Bar, FooProxy, BarProxy
+from .models import Foo, Bar, FooProxy, BarProxy, BarChild, FooChildProxy
 
 
 class TestRelated(TestCase):
@@ -28,6 +28,25 @@ class TestRelated(TestCase):
             foo.bar.__class__
         )
 
+    def test_fk_child_override_child(self):
+        bar_child = BarChild.objects.create()
+        Foo.objects.create(bar=bar_child)
+
+        foo = FooChildProxy.objects.get()
+
+        self.assertEqual(
+            FooChildProxy,
+            foo.__class__
+        )
+
+        self.assertEqual(
+            BarChild,
+            foo.bar.__class__
+        )
+
+        assert foo.bar.a == 1
+        assert foo.bar.b == 2
+
     def test_reverse_fk_field_override(self):
         bar = Bar.objects.create()
         Foo.objects.create(bar=bar)
@@ -44,12 +63,21 @@ class TestRelated(TestCase):
             bar.foo_set.model
         )
 
-    def test_exception_if_not_proxy_target(self):
-        with self.assertRaises(TypeError):
-            from proxy_overrides.related import ProxyForeignKey
+    def test_reverse_fk_field_child_child(self):
+        bar_child = BarChild.objects.create()
+        Foo.objects.create(bar=bar_child)
 
-            class FooNewProxy(Foo):
-                bar = ProxyForeignKey(Bar)
+        bar_child = BarChild.objects.get()
+
+        self.assertEqual(
+            BarChild,
+            bar_child.__class__
+        )
+
+        self.assertEqual(
+            FooChildProxy,
+            bar_child.foo_set.model
+        )
 
     def test_exception_if_same_relation(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Hi @schinckel, I removed the requirement that the proxyforeignkey only point to another proxy model. Things seem to work fine (and tests pass for the case that I am working on right now). 

Would you mind giving some insight as to why you had this restriction. Thanks so much!