### PR TITLE
Allow referencing related models as string

### DIFF
--- a/proxy_overrides/base.py
+++ b/proxy_overrides/base.py
@@ -1,7 +1,11 @@
 from django.dispatch import receiver
 
 from django.db.models import signals
-from django.db.models.fields.related import ReverseManyToOneDescriptor
+from django.db.models.fields.related import lazy_related_operation, ReverseManyToOneDescriptor
+
+
+class ProxyRelationAlreadyExists(TypeError):
+    pass
 
 
 def override_model_field(model, name, field):
@@ -14,27 +18,32 @@ def override_model_field(model, name, field):
         ))
 
     if field.remote_field:
+        def after_resolve_related_class(model, field_remote_field_model, field):
+            related_name = field.remote_field.related_name
+            if not related_name:
+                related_name = original_field.remote_field.get_accessor_name()
+            related_model = getattr(field_remote_field_model, related_name).rel.model
 
-        related_name = field.remote_field.related_name
-        if not related_name:
-            related_name = original_field.remote_field.get_accessor_name()
-        related_model = getattr(field.remote_field.model, related_name).rel.model
+            if related_model._meta.proxy:
+                raise ProxyRelationAlreadyExists('There is already a proxy model {!r} related to {!r} using {!r}'.format(
+                    related_model.__name__,
+                    model.__name__,
+                    related_name
+                ))
 
-        if related_model._meta.proxy:
-            raise TypeError('There is already a proxy model {!r} related to {!r} using {!r}'.format(
-                related_model.__name__,
-                field.remote_field.model.__name__,
-                related_name
-            ))
+            model.add_to_class(name, field)
+            model._meta.local_fields.remove(field)
 
-    model.add_to_class(name, field)
-    model._meta.local_fields.remove(field)
+            field.remote_field.model.add_to_class(
+                related_name,
+                ReverseManyToOneDescriptor(field.remote_field)
+            )
 
-    if field.remote_field:
-        field.remote_field.model.add_to_class(
-            related_name,
-            ReverseManyToOneDescriptor(field.remote_field)
-        )
+        # https://github.com/django/django/blob/stable/2.2.x/django/db/models/fields/related.py#L62
+        lazy_related_operation(after_resolve_related_class, model, field.remote_field.model, field=field)
+    else:
+        model.add_to_class(name, field)
+        model._meta.local_fields.remove(field)
 
 
 class ProxyField(object):

--- a/tests/models.py
+++ b/tests/models.py
@@ -21,6 +21,7 @@ class BarChild(Bar):
 
 
 class FooProxy(Foo):
+    # reference related model directly
     bar = ProxyForeignKey(BarProxy, on_delete='null')
 
     class Meta:
@@ -28,7 +29,8 @@ class FooProxy(Foo):
 
 
 class FooChildProxy(Foo):
-    bar = ProxyForeignKey(BarChild, on_delete='null')
+    # related model passed as string
+    bar = ProxyForeignKey('BarChild', on_delete='null')
 
     class Meta:
         proxy = True

--- a/tests/test_related.py
+++ b/tests/test_related.py
@@ -1,3 +1,5 @@
+from proxy_overrides.base import ProxyRelationAlreadyExists
+
 from django.test import TestCase
 
 from .models import Foo, Bar, FooProxy, BarProxy, BarChild, FooChildProxy
@@ -80,8 +82,8 @@ class TestRelated(TestCase):
         )
 
     def test_exception_if_same_relation(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ProxyRelationAlreadyExists):
             from proxy_overrides.related import ProxyForeignKey
 
             class FooNewProxy(Foo):
-                bar = ProxyForeignKey(BarProxy)
+                bar = ProxyForeignKey('BarProxy', on_delete='null')


### PR DESCRIPTION
* use lazy_related_operation to resolve related model later
* add missing on_delete argument to test case
* add more specific exception ProxyRelationAlreadyExists to make test more robust
* fix incorrect model name in ProxyRelationAlreadyExists error message