### PR TITLE
Plus related name

### DIFF
--- a/proxy_overrides/base.py
+++ b/proxy_overrides/base.py
@@ -14,27 +14,26 @@ def override_model_field(model, name, field):
         ))
 
     if field.remote_field:
-
         related_name = field.remote_field.related_name
         if not related_name:
             related_name = original_field.remote_field.get_accessor_name()
-        related_model = getattr(field.remote_field.model, related_name).rel.model
+        if related_name != '+':
+            related_model = getattr(field.remote_field.model, related_name).rel.model
 
-        if related_model._meta.proxy:
-            raise TypeError('There is already a proxy model {!r} related to {!r} using {!r}'.format(
-                related_model.__name__,
-                field.remote_field.model.__name__,
-                related_name
-            ))
+            if related_model._meta.proxy:
+                raise TypeError('There is already a proxy model {!r} related to {!r} using {!r}'.format(
+                    related_model.__name__,
+                    field.remote_field.model.__name__,
+                    related_name
+                ))
+
+            field.remote_field.model.add_to_class(
+                related_name,
+                ReverseManyToOneDescriptor(field.remote_field)
+            )
 
     model.add_to_class(name, field)
     model._meta.local_fields.remove(field)
-
-    if field.remote_field:
-        field.remote_field.model.add_to_class(
-            related_name,
-            ReverseManyToOneDescriptor(field.remote_field)
-        )
 
 
 class ProxyField(object):

--- a/tests/models.py
+++ b/tests/models.py
@@ -11,6 +11,10 @@ class Bar(models.Model):
     a = models.IntegerField(default=1)
 
 
+class UnrelatedFoo(models.Model):
+    bar = models.ForeignKey('tests.Bar', related_name='+', on_delete='null')
+
+
 class BarProxy(Bar):
     class Meta:
         proxy = True
@@ -40,6 +44,18 @@ class Baz(models.Model):
 
 class BazProxy(Baz):
     integer = ProxyField(models.IntegerField(default=3))
+
+    class Meta:
+        proxy = True
+
+
+class UnrelatedBarProxy(Bar):
+    class Meta:
+        proxy = True
+
+
+class UnrelatedFooProxy(UnrelatedFoo):
+    bar = ProxyForeignKey(UnrelatedBarProxy, on_delete='null')
 
     class Meta:
         proxy = True

--- a/tests/test_related.py
+++ b/tests/test_related.py
@@ -1,6 +1,16 @@
 from django.test import TestCase
 
-from .models import Foo, Bar, FooProxy, BarProxy, BarChild, FooChildProxy
+from .models import (
+    Foo,
+    Bar,
+    FooProxy,
+    BarProxy,
+    BarChild,
+    FooChildProxy,
+    UnrelatedFoo,
+    UnrelatedFooProxy,
+    UnrelatedBarProxy,
+)
 
 
 class TestRelated(TestCase):
@@ -85,3 +95,19 @@ class TestRelated(TestCase):
 
             class FooNewProxy(Foo):
                 bar = ProxyForeignKey(BarProxy)
+
+    def test_unrelated_proxy(self):
+        bar = Bar.objects.create()
+        UnrelatedFoo.objects.create(bar=bar)
+
+        foo = UnrelatedFooProxy.objects.get()
+
+        self.assertEqual(
+            UnrelatedFooProxy,
+            foo.__class__
+        )
+
+        self.assertEqual(
+            UnrelatedBarProxy,
+            foo.bar.__class__
+        )


### PR DESCRIPTION
- Add support of [`related_name='+'`](https://docs.djangoproject.com/en/2.2/ref/models/fields/#django.db.models.ForeignKey.related_name
)
- Add coverage